### PR TITLE
Add a lower bound sleep parameter to ExponentialBackoff

### DIFF
--- a/src/main/scala/com/gilt/gfc/util/ExponentialBackoff.scala
+++ b/src/main/scala/com/gilt/gfc/util/ExponentialBackoff.scala
@@ -8,6 +8,11 @@ import com.gilt.gfc.logging.Loggable
 trait ExponentialBackoff extends Loggable {
 
   /**
+   * Optional setting to wait a minimum time before a retry, defaulting to 1ms
+   */
+  protected def backoffMinTimeMs: Long = 1L
+
+  /**
    * To be injected, max backoff time in millis.
    */
   protected def backoffMaxTimeMs: Long
@@ -19,7 +24,7 @@ trait ExponentialBackoff extends Loggable {
    */
   protected[this] final def loopWithBackoffOnErrorWhile(loopCondition: => Boolean)
                                                        (loopBody: => Unit) {
-    var currentSleepTimeMs = 1L
+    var currentSleepTimeMs = backoffMinTimeMs
     while(loopCondition) {
       try {
         loopBody

--- a/src/test/scala/com/gilt/gfc/util/ExponentialBackoffTest.scala
+++ b/src/test/scala/com/gilt/gfc/util/ExponentialBackoffTest.scala
@@ -78,6 +78,24 @@ class ExponentialBackoffTest extends FunSuite with Matchers {
     }
   }
 
+  test("backoff sleeps the min duration") {
+    new ExponentialBackoff with Loggable {
+      override val backoffMinTimeMs = 64L
+      override val backoffMaxTimeMs = 150L
+
+      val timestamps = new scala.collection.mutable.ListBuffer[Long]()
+
+      retry {
+        timestamps += System.currentTimeMillis()
+        if (timestamps.size < 5) sys.error("")
+      }
+
+      val lapses = timestamps.sliding(2).toSeq.map(t => t(1) - t(0))
+      lapses.size should be (4)
+      lapses.foreach(_ should be >= 64L)
+    }
+  }
+
   test("backoff maxes out") {
     new ExponentialBackoff with Loggable {
       override val backoffMaxTimeMs = 100L


### PR DESCRIPTION
Companion setting to backoffMaxTimeMs which provides an upper bound